### PR TITLE
Do not use exit() on mobile platforms

### DIFF
--- a/Sources/ArgTree.swift
+++ b/Sources/ArgTree.swift
@@ -86,7 +86,9 @@ public class ArgTree: ParserNode {
     public convenience init(helpText: String,
                             parsers: [Parser] = [],
                             helpPrinted: @escaping () -> Void = {
+                            #if os(macOS) || os(Linux)
                                 exit(0)
+                            #endif
                             }) {
         self.init(parsers: parsers)
         let writeHelp: () -> Void = {
@@ -106,7 +108,9 @@ public class ArgTree: ParserNode {
     public convenience init(description: String,
                             parsers: [Parser] = [],
                             helpPrinted: @escaping () -> Void = {
+                            #if os(macOS) || os(Linux)
                                 exit(0)
+                            #endif
                             }) {
         self.init(parsers: parsers)
         let printHelp: () -> Void = {

--- a/Sources/ArgTree.swift
+++ b/Sources/ArgTree.swift
@@ -1,6 +1,6 @@
-#if os(macOS)
+#if canImport(Darwin)
 import Darwin
-#elseif os(Linux)
+#elseif canImport(Glibc)
 import Glibc
 #endif
 
@@ -86,9 +86,7 @@ public class ArgTree: ParserNode {
     public convenience init(helpText: String,
                             parsers: [Parser] = [],
                             helpPrinted: @escaping () -> Void = {
-                            #if os(macOS) || os(Linux)
                                 exit(0)
-                            #endif
                             }) {
         self.init(parsers: parsers)
         let writeHelp: () -> Void = {
@@ -108,9 +106,7 @@ public class ArgTree: ParserNode {
     public convenience init(description: String,
                             parsers: [Parser] = [],
                             helpPrinted: @escaping () -> Void = {
-                            #if os(macOS) || os(Linux)
                                 exit(0)
-                            #endif
                             }) {
         self.init(parsers: parsers)
         let printHelp: () -> Void = {

--- a/Sources/parsers/Command.swift
+++ b/Sources/parsers/Command.swift
@@ -1,6 +1,6 @@
-#if os(macOS)
+#if canImport(Darwin)
 import Darwin
-#elseif os(Linux)
+#elseif canImport(Glibc)
 import Glibc
 #endif
 
@@ -41,9 +41,7 @@ open class Command: ValueParser<Bool>, ParserNode {
                 parsed: OnParsed? = nil,
                 parsers: [Parser] = [],
                 helpPrinted: @escaping () -> Void = {
-                #if os(macOS) || os(Linux)
                     exit(0)
-                #endif
                 },
                 afterChildrenParsed: OnParsed? = nil) {
 

--- a/Sources/parsers/Command.swift
+++ b/Sources/parsers/Command.swift
@@ -41,7 +41,9 @@ open class Command: ValueParser<Bool>, ParserNode {
                 parsed: OnParsed? = nil,
                 parsers: [Parser] = [],
                 helpPrinted: @escaping () -> Void = {
+                #if os(macOS) || os(Linux)
                     exit(0)
+                #endif
                 },
                 afterChildrenParsed: OnParsed? = nil) {
 

--- a/Tests/argtreeTests/XCTestManifests.swift
+++ b/Tests/argtreeTests/XCTestManifests.swift
@@ -14,7 +14,7 @@ func setUpLogger() {
     }
 }
 
-#if !os(macOS)
+#if os(Linux)
 public func allTests() -> [XCTestCaseEntry] {
     return [
         testCase(ArgTreeTests.allTests),


### PR DESCRIPTION
Hi,

I try to use your library on iOS but get some compiler errors. The exit() method cannot be used on mobile platforms. Therefore Xcode reports some compiler errors. To use it anyway, I added a preprocessor statement to switch between mobile platforms and macOS/Linux.